### PR TITLE
OMS: adb shell command to access OverlayManagerService

### DIFF
--- a/target/product/base.mk
+++ b/target/product/base.mk
@@ -102,6 +102,7 @@ PRODUCT_PACKAGES += \
     mtpd \
     ndc \
     netd \
+    om \
     ping \
     ping6 \
     platform.xml \


### PR DESCRIPTION
Add a command to communicate with the OverlayManagerService for
debugging purposes. This mirrors the am and pm commands.

Example use:
    $ adb shell om list
    com.android.systemui
        [ ] com.test.awesome-home-button

```
$ adb shell om enable com.test.awesome-home-button

$ adb shell om list
com.android.systemui
    [x] com.test.awesome-home-button
```

Co-authored-by: Martin Wallgren martin.wallgren@sonymobile.com
Signed-off-by: Zoran Jovanovic zoran.jovanovic@sonymobile.com

Change-Id: If84fa20dd11ca2fa1ee64f452d0dae86673720b2
